### PR TITLE
updated typing in consumers

### DIFF
--- a/chats_app/consumers.py
+++ b/chats_app/consumers.py
@@ -173,13 +173,23 @@ class ChatConsumer(AsyncWebsocketConsumer):
             'is_typing': event['is_typing'],
         }))
 
+    # async def chat_typing(self, event):
+    #     if self.scope['user'].id != event['sender']:
+    #         await self.send(text_data=json.dumps({
+    #             'type': 'typing',
+    #             'sender': event['sender'],
+    #             'sender_name': event['sender_name'],
+    #             'is_typing': event['is_typing'],
+    #         }))
+
     async def chat_typing(self, event):
-        if self.scope['user'].id != event['sender']:
-            await self.send(text_data=json.dumps({
-                'type': 'typing',
-                'sender': event['sender'],
-                'sender_name': event['sender_name'],
-                'is_typing': event['is_typing'],
+        if getattr(self, 'user', None) and self.user.id == event.get('sender'):
+            return
+        await self.send(text_data=json.dumps({
+            'type': 'typing',
+            'sender': event['sender'],
+            'sender_name': event['sender_name'],
+            'is_typing': event['is_typing'],
             }))
 
     @database_sync_to_async

--- a/lugha_app/templates/emails/signup-verification.html
+++ b/lugha_app/templates/emails/signup-verification.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LughaNest Account Verification</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: 'Lora', sans-serif;
+            background-color: #FAF3E0;
+            color: #000000;
+            line-height: 1.6;
+            font-weight: 600;
+            -webkit-font-smoothing: antialiased;
+        }
+        
+        .email-container {
+            max-width: 600px;
+            margin: 0 auto;
+            background-color: #FAF3E0;
+        }
+        
+        .email-header {
+            padding: 20px;
+            text-align: left;
+            background-color: #E9D6B8;
+            margin: 20px;
+            border-radius: 5px;
+        }
+        
+        .email-body {
+            padding: 30px;
+            background-color: #FAF3E0;
+            border-radius: 5px;
+            margin: 20px;
+            border: 1px solid #A78F74;
+        }
+        
+        .email-footer {
+            padding: 20px;
+            text-align: center;
+            font-size: 12px;
+            color: #000000;
+            background-color: #E9D6B8;
+            margin: 20px;
+            border-radius: 5px;
+        }
+        
+        h1, h2, h3, h4, h5, h6 {
+            font-family: 'Poppins', sans-serif;
+            color: #000000;
+        }
+        
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            background-color: #E9D6B8;
+            color: #000000 !important;
+            text-decoration: none;
+            border-radius: 4px;
+            font-weight: bold;
+            margin: 20px 0;
+            text-align: center;
+            border: none;
+            cursor: pointer;
+        }
+        
+        .button:hover {
+            background-color:rgb(197, 172, 123);
+        }
+        
+        .divider {
+            height: 1px;
+            background-color: #A78F74;
+            margin: 25px 0;
+        }
+        
+        .logo {
+            font-family: 'Poppins', sans-serif;
+            font-size: 24px;
+            font-weight: bold;
+            color: #000000;
+        }
+        
+        .text-center {
+            text-align: center;
+        }
+        
+        .activation-link {
+            word-break: break-all;
+            background-color: #E9D6B8;
+            padding: 15px;
+            border-radius: 4px;
+            border: 1px dashed #A78F74;
+            font-family: monospace;
+        }
+        
+        /* Responsive styles */
+        @media screen and (max-width: 600px) {
+            .email-body {
+                padding: 20px;
+                margin: 10px;
+            }
+            
+            .button {
+                display: block;
+                margin: 20px auto;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="email-container">
+        <div class="email-header">
+            <div class="logo">LughaNest Account Verification</div>
+        </div>
+        
+        <div class="email-body">         
+            <p>Hello {{user.first_name}},</p>
+
+               
+            <p>Thank you for creating an account with LughaNest! To complete your registration, please verify your email address by clicking the button below:</p>
+            
+              <div class="text-center">
+                <a href="{{activation_link}}" class="button">Activate Account</a>
+            </div>
+            
+            <p>Or follow the link to verify and activate your account.</p>
+            
+                  <p class="activation-link">{{activation_link}}</p>
+          
+            
+            <div class="divider"></div>
+            
+            <p>LughaNest Team</p>
+        </div>
+
+          <div class="email-footer">
+            <p>&copy; LughaNest. All rights reserved.</p>
+            <p>If you need assistance, please contact our support team.</p>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary by Sourcery

Switch account verification emails to a styled HTML template with plaintext fallback and refine chat_typing consumer logic to avoid echoing typing events to the sender

New Features:
- Add HTML email template for account verification and enable sending multi-part verification emails with HTML and plaintext versions

Bug Fixes:
- Prevent chat consumer from echoing typing indicators back to the original sender

Enhancements:
- Replace send_mail with EmailMultiAlternatives for richer account verification emails